### PR TITLE
fix: adjusting ManagementAccountID parameter allowed pattern

### DIFF
--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -193,7 +193,7 @@ Parameters:
     Default: Lambda-Assume-Role-Management-Account
   ManagementAccountID:
     Type: String
-    AllowedPattern: ([a-z0-9\-, ]*?$)
+    AllowedPattern: ^(\d{12})(,\d{12})*$
     Description: "(Ex: 123456789,098654321,789054312) List of Payer IDs you wish to collect data for. Can just be one Accounts"
   MultiAccountRoleName:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Permit multiple account IDs in CSV format, with each account ID conforming to the correct format for account identifiers (12 digits).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
