### PR TITLE
Fix: adding iam:TagRole permission for Compute Optimizer StackSetExecution role

### DIFF
--- a/data-collection/deploy/module-compute-optimizer.yaml
+++ b/data-collection/deploy/module-compute-optimizer.yaml
@@ -134,6 +134,7 @@ Resources:
                   - iam:DeleteRolePolicy
                   - iam:GetRolePolicy
                   - iam:PutRolePolicy
+                  - iam:TagRole
                 Resource:
                   - !Sub 'arn:aws:iam::${AWS::AccountId}:role/${ResourcePrefix}Compute-Optimizer-Replication-*'
                   - !Sub 'arn:aws:iam::${AWS::AccountId}:role/StackSet-${ResourcePrefix}ComputeOptimizer*' # For Compatibility with older versions: Shorter version of StackSetName


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tagging is used for the stack set provisioned in the compute optimizer module.

Deployments of regional bucket replication roles fail for regions other than the one where the data collection stack is being deployed.

The permission iam:TagRole is added to ensure the stack set execution role can tag the roles created by the compute optimizer buckets stack set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
