### PR TITLE
Initial addition of automatic manual account list mode

### DIFF
--- a/data-collection/deploy/account-collector.yaml
+++ b/data-collection/deploy/account-collector.yaml
@@ -11,6 +11,13 @@ Parameters:
   ResourcePrefix:
     Type: String
     Description: This prefix will be placed in front of all roles created. Note you may wish to add a dash at the end to make more readable
+  DestinationBucket:
+    Type: String
+    Description: Name of the S3 Bucket to be created to hold data information
+    AllowedPattern: (?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)
+  DestinationBucketARN:
+    Type: String
+    Description: ARN of the S3 Bucket that exists or needs to be created to hold rightsizing information
 Outputs:
   LambdaFunctionName:
     Value: !Ref LambdaFunction
@@ -71,6 +78,15 @@ Resources:
                 Action:
                   - "lambda:GetAccountSettings"
                 Resource: "*"
+        - PolicyName: "S3-Access"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "s3:GetObject"
+                Resource:
+                  - !Sub "${DestinationBucketARN}/*"
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -96,6 +112,8 @@ Resources:
             ROLE_NAME = os.environ['ROLE_NAME']
             RESOURCE_PREFIX = os.environ['RESOURCE_PREFIX']
             MANAGEMENT_ACCOUNT_IDS = os.environ['MANAGEMENT_ACCOUNT_IDS']
+            BUCKET = os.environ['BUCKET_NAME']
+            ACCOUNT_LIST_KEY = os.environ['ACCOUNT_LIST_KEY']
 
             logger = logging.getLogger(__name__)
             logger.setLevel(getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper(), logging.INFO))
@@ -121,6 +139,7 @@ Resources:
                 account_type = event.get("Type", '').lower()
                 if account_type not in functions:
                     raise Exception(f"Lambda event must have 'Type' parameter with value = ({list(functions.keys())})") #pylint: disable=broad-exception-raised
+
                 account_iterator = functions[account_type]
                 accounts = list(account_iterator())
                 if not accounts:
@@ -144,29 +163,40 @@ Resources:
                     yield {"account": json.dumps({'account_id': account_id, 'account_name': '', 'payer_id': payer_id})}
 
             def iterate_linked_accounts():
-                for org_account_data in iterate_admins_accounts('organizations'):
-                    org_account = json.loads(org_account_data['account'])
-                    try:
-                        organizations = get_client_with_role(service="organizations", account_id=org_account['account_id'], region="us-east-1") #MUST be us-east-1
-                        for account in organizations.get_paginator("list_accounts").paginate().search("Accounts[?Status=='ACTIVE']"):
-                            yield {
-                                "account": json.dumps({
-                                    'account_id': account.get('Id'),
-                                    'account_name': account.get('Name'),
-                                    'payer_id': org_account['payer_id'],
-                                })
-                            }
-                    except Exception as exc: #pylint: disable=broad-exception-caught
-                        logger.error(f'{org_account}: {exc}')
+                defined_accounts = get_defined_list(ACCOUNT_LIST_KEY)
+                try:
+                    if defined_accounts:
+                        logger.info(f'Using defined account list instead of payer organization')
+                        for account_data in defined_accounts:
+                            account = json.loads(account_data)
+                            yield format_account(account['account_id'], account['account_name'], account['payer_id'])
+                    else:
+                        logger.info(f'Using payer organization for the account list')
+                        for org_account_data in iterate_admins_accounts('organizations'):
+                            org_account = json.loads(org_account_data['account'])
+                            organizations = get_client_with_role(service="organizations", account_id=org_account['account_id'], region="us-east-1") #MUST be us-east-1
+                            for account in organizations.get_paginator("list_accounts").paginate().search("Accounts[?Status=='ACTIVE']"):
+                                yield format_account(account.get('Id'), account.get('Name'), org_account['payer_id'])
+                except Exception as exc: #pylint: disable=broad-exception-caught
+                    logger.error(f'{org_account}: {exc}')
 
-            def dummy_iterate_linked_accounts():
-                # use this function if you have no access to payer or delegated admin at all
-                hardcoded_accounts = [
-                    {'account_id': '111222333444', 'account_name': 'replaceme', 'payer_id': '666777888999'},
-                    {'account_id': '555666777888', 'account_name': 'replaceme', 'payer_id': '666777888999'},
-                ]
-                for account_data in hardcoded_accounts:
-                    yield {"account": json.dumps(account_data)}
+            def get_defined_list(key):
+                s3 = boto3.client("s3")
+                try:
+                    accts = s3.get_object(Bucket=BUCKET, Key=key)
+                    return accts['Body'].read().decode('utf-8').strip('\n').split('\n')
+                except Exception as exc: #pylint: disable=broad-exception-caught
+                    logger.debug(f'Predefined account list not retrieved or not being used {exc}')
+                    return None
+
+            def format_account(account_id, account_name, payer_id):
+                return {
+                    "account": json.dumps({
+                        'account_id': account_id,
+                        'account_name': account_name,
+                        'payer_id': payer_id,
+                    })
+                }
 
             def get_client_with_role(account_id, service, region):
                 credentials = boto3.client('sts').assume_role(
@@ -190,6 +220,8 @@ Resources:
           ROLE_NAME: !Ref ManagementRoleName
           MANAGEMENT_ACCOUNT_IDS: !Ref ManagementAccountID
           RESOURCE_PREFIX: !Ref ResourcePrefix
+          BUCKET_NAME: !Ref DestinationBucket
+          ACCOUNT_LIST_KEY: "account-list/account-list.json"
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/data-collection/deploy/account-collector.yaml
+++ b/data-collection/deploy/account-collector.yaml
@@ -163,13 +163,17 @@ Resources:
                     yield {"account": json.dumps({'account_id': account_id, 'account_name': '', 'payer_id': payer_id})}
 
             def iterate_linked_accounts():
-                defined_accounts = get_defined_list(ACCOUNT_LIST_KEY)
+                defined_accounts, ext = get_defined_list(BUCKET, ACCOUNT_LIST_KEY)
                 try:
                     if defined_accounts:
                         logger.info(f'Using defined account list instead of payer organization')
                         for account_data in defined_accounts:
-                            account = json.loads(account_data)
-                            yield format_account(account['account_id'], account['account_name'], account['payer_id'])
+                            if ext == "json":
+                                account = json.loads(account_data)
+                                yield format_account(account['account_id'], account['account_name'], account['payer_id'])
+                            else:
+                                account = account_data.split(',')
+                                yield format_account(account[0], account[1], account[2])
                     else:
                         logger.info(f'Using payer organization for the account list')
                         for org_account_data in iterate_admins_accounts('organizations'):
@@ -180,14 +184,17 @@ Resources:
                 except Exception as exc: #pylint: disable=broad-exception-caught
                     logger.error(f'{org_account}: {exc}')
 
-            def get_defined_list(key):
+            def get_defined_list(bucket, key):
                 s3 = boto3.client("s3")
-                try:
-                    accts = s3.get_object(Bucket=BUCKET, Key=key)
-                    return accts['Body'].read().decode('utf-8').strip('\n').split('\n')
-                except Exception as exc: #pylint: disable=broad-exception-caught
-                    logger.debug(f'Predefined account list not retrieved or not being used {exc}')
-                    return None
+                exts = ["json", "csv"]
+                for ext in exts:
+                    try:
+                        accts = s3.get_object(Bucket=bucket, Key=f"{key}.{ext}")
+                        return accts['Body'].read().decode('utf-8').strip('\n').split('\n'), ext
+                    except Exception as exc: #pylint: disable=broad-exception-caught
+                        continue
+                logger.debug(f'Predefined account list not retrieved or not being used')
+                return None, None
 
             def format_account(account_id, account_name, payer_id):
                 return {
@@ -221,7 +228,7 @@ Resources:
           MANAGEMENT_ACCOUNT_IDS: !Ref ManagementAccountID
           RESOURCE_PREFIX: !Ref ResourcePrefix
           BUCKET_NAME: !Ref DestinationBucket
-          ACCOUNT_LIST_KEY: "account-list/account-list.json"
+          ACCOUNT_LIST_KEY: "account-list/account-list"
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/data-collection/deploy/account-collector.yaml
+++ b/data-collection/deploy/account-collector.yaml
@@ -166,7 +166,7 @@ Resources:
                 defined_accounts, ext = get_defined_list(BUCKET, ACCOUNT_LIST_KEY)
                 try:
                     if defined_accounts:
-                        logger.info(f'Using defined account list instead of payer organization')
+                        logger.info(f'Using defined account list {ACCOUNT_LIST_KEY}.{ext} instead of payer organization')
                         for account_data in defined_accounts:
                             if ext == "json":
                                 account = json.loads(account_data)

--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -1130,3 +1130,5 @@ Resources:
         ManagementRoleName: !Sub "${ResourcePrefix}${ManagementAccountRole}"
         ManagementAccountID: !Ref ManagementAccountID
         ResourcePrefix: !Ref ResourcePrefix
+        DestinationBucket: !Ref S3Bucket
+        DestinationBucketARN: !GetAtt S3Bucket.Arn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allows user to deploy a pre-defined list of accounts in the event they cannot use a payer/orgs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
