### PR TITLE
CO Hub details crawler table threshold to 1 to prevent sprawl from sc…

### DIFF
--- a/data-collection/deploy/module-cost-optimization-hub.yaml
+++ b/data-collection/deploy/module-cost-optimization-hub.yaml
@@ -436,6 +436,9 @@ Resources:
           "CrawlerOutput": {
             "Partitions": {
               "AddOrUpdateBehavior": "InheritFromTable"
+            },
+            "Tables": {
+              "TableThreshold": 1
             }
           }
         }


### PR DESCRIPTION
This mod will force an error to prevent sprawl from schema fix for customers with legacy CO Hub data. Customer should then delete previously gathered data and potentially the table to restore a single table for analysis.
