### PR TITLE
Adding AWS Budgets tag collection and updated IAM permissions

### DIFF
--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -164,6 +164,7 @@ Resources:
             Action:
               - "budgets:ViewBudget"
               - "budgets:DescribeBudgets"
+              - "budgets:ListTagsForResource"
             Resource: "arn:aws:budgets::*:budget/*"
       Roles:
         - Ref: LambdaRole

--- a/data-collection/deploy/module-budgets.yaml
+++ b/data-collection/deploy/module-budgets.yaml
@@ -103,11 +103,16 @@ Resources:
       Code:
         ZipFile: |
           #Author Stephanie Gooch 2021
+          #Mohideen - Added Budgets tag collection module
           import os
           import json
           import logging
           import datetime
           from json import JSONEncoder
+          import sys
+          from pip._internal import main
+          main(['install', '-I', '-q', 'boto3', '--target', '/tmp/', '--no-cache-dir', '--disable-pip-version-check'])
+          sys.path.insert(0,'/tmp/')
 
           import boto3
 
@@ -164,7 +169,17 @@ Resources:
                               count += 1
                               budget['collection_time'] = collection_time
                               logger.debug(budget)
-                              budget.update({'Account_ID': account_id, 'Account_Name': account_name})
+                              # Fetch tags for the budget using List tag for resource API
+                              budget_name = budget['BudgetName']
+                              resource_arn = f"arn:aws:budgets::{account_id}:budget/{budget_name}"
+                              budget_tag = budgets_client.list_tags_for_resource(
+                                  ResourceARN=f"{resource_arn}"
+                              )
+                              if budget_tag['ResourceTags'] is not None:
+                                budget.update({'Account_ID': account_id, 'Account_Name': account_name, 'Tags': budget_tag['ResourceTags']})
+                              else:
+                                budget.update({'Account_ID': account_id, 'Account_Name': account_name})
+                              # Fetch CostFilters if available
                               if 'CostFilters' not in budget or len(budget['CostFilters']) == 0 or 'PlannedBudgetLimits' not in budget:
                                   budget.update({'CostFilters': {'Filter': ['None']}})
                               dataJSONData = json.dumps(budget, cls=DateTimeEncoder)


### PR DESCRIPTION
This update brings following enhancements

1. To add additional IAM Permissions needed to fetch tags in AWS budgets.
2. Updates to the AWS Lambda function to fetch the tags along with the budgets.
3. This update also addresses the issue #124


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
