### PR TITLE
Fix the issue with ReplicationPolicy

### DIFF
--- a/security-hub/deploy/module-securityhub.yaml
+++ b/security-hub/deploy/module-securityhub.yaml
@@ -809,7 +809,7 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${DatabaseName}/*
-              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${DatabaseName}
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${DatabaseName}
           - Sid: AllowListBucket
             Effect: Allow
             Action: s3:ListBucket

--- a/security-hub/deploy/module-securityhub.yaml
+++ b/security-hub/deploy/module-securityhub.yaml
@@ -12,7 +12,7 @@ Metadata:
           - DestinationBucketPrefix
           - CFDataName
       - Label:
-          default: '(OPTIONAL) Consolidate Security Hub Data Across AWS Organizations'
+          default: 'Consolidate Security Hub Data Across AWS Organizations'
         Parameters:
           - AcceptDataFromAccountIDs
           - SendDataToAccountID
@@ -97,7 +97,7 @@ Resources:
                   - s3:ReplicateObject
                   - s3:ReplicateDelete
                   - s3:ReplicateTags
-                Resource: !Sub "arn:${AWS::Partition}:s3:::${DestinationBucketPrefix}${SendDataToAccountID}-security-hub/security-hub/*"
+                Resource: !Sub "arn:${AWS::Partition}:s3:::${DestinationBucketPrefix}${SendDataToAccountID}-security-hub/${CFDataName}/*"
 
   DestinationBucket:
     Type: 'AWS::S3::Bucket'
@@ -809,7 +809,7 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${DatabaseName}/*
-              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${DatabaseName}
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${DatabaseName}
           - Sid: AllowListBucket
             Effect: Allow
             Action: s3:ListBucket

--- a/security-hub/deploy/module-securityhub.yaml
+++ b/security-hub/deploy/module-securityhub.yaml
@@ -12,7 +12,7 @@ Metadata:
           - DestinationBucketPrefix
           - CFDataName
       - Label:
-          default: 'Consolidate Security Hub Data Across AWS Organizations'
+          default: '(OPTIONAL) Consolidate Security Hub Data Across AWS Organizations'
         Parameters:
           - AcceptDataFromAccountIDs
           - SendDataToAccountID


### PR DESCRIPTION

*Issue #, if available:*
Resource" arn in "ReplicationPolicy" was incorrect and leading to errors while replicating objects to cross account bucket for centralized logging.

*Description of changes:*
Changed "Resource" arn in "ReplicationPolicy" for "ReplicationRole" to "arn:${AWS::Partition}:s3:::${DestinationBucketPrefix}${SendDataToAccountID}-security-hub/${CFDataName}/*"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
