### PR TITLE
Get error message by converting exception to string

### DIFF
--- a/data-collection/deploy/module-backup.yaml
+++ b/data-collection/deploy/module-backup.yaml
@@ -228,7 +228,7 @@ Resources:
               try:
                   count = store_to_s3(flatten_data_iterator, s3_prefix)
               except backup.exceptions.ClientError as exc:
-                  if 'Insufficient privileges to perform this action.' in exc["errorMessage"]:
+                  if 'Insufficient privileges to perform this action.' in str(exc):
                       raise Exception(
                         'You need to activate cross account jobs monitoring '
                         'https://docs.aws.amazon.com/aws-backup/latest/devguide/manage-cross-account.html#enable-cross-account'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`exc["errorMessage"]` fails because exc is not a dictionary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
